### PR TITLE
Migrate both provider functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,10 @@ module.exports = {
 
     {
       files: ['*.test.ts', '*.test.js'],
-      extends: ['@metamask/eslint-config-jest'],
+      extends: [
+        '@metamask/eslint-config-jest',
+        '@metamask/eslint-config-nodejs',
+      ],
     },
   ],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "test": "jest && jest-it-up",
     "test:watch": "jest --watch"
   },
+  "dependencies": {
+    "@metamask/safe-event-emitter": "^2.0.0",
+    "json-rpc-engine": "^6.1.0"
+  },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
     "@metamask/auto-changelog": "^3.1.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,12 @@
-import greeter from '.';
+import * as allExports from '.';
 
-describe('Test', () => {
-  it('greets', () => {
-    const name = 'Huey';
-    const result = greeter(name);
-    expect(result).toBe('Hello, Huey!');
+describe('Package exports', () => {
+  it('has expected exports', () => {
+    expect(Object.keys(allExports)).toMatchInlineSnapshot(`
+      Array [
+        "providerFromEngine",
+        "providerFromMiddleware",
+      ]
+    `);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,2 @@
-/**
- * Example function that returns a greeting for the given name.
- *
- * @param name - The name to greet.
- * @returns The greeting.
- */
-export default function greeter(name: string): string {
-  return `Hello, ${name}!`;
-}
+export * from './provider-from-engine';
+export * from './provider-from-middleware';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './provider-from-engine';
 export * from './provider-from-middleware';
+export type { SafeEventEmitterProvider } from './safe-event-emitter-provider';

--- a/src/provider-from-engine.test.ts
+++ b/src/provider-from-engine.test.ts
@@ -1,0 +1,43 @@
+import { JsonRpcEngine } from 'json-rpc-engine';
+import { promisify } from 'util';
+
+import { providerFromEngine } from './provider-from-engine';
+
+describe('providerFromEngine', () => {
+  it('handle a successful request', async () => {
+    const engine = new JsonRpcEngine();
+    engine.push((_req, res, _next, end) => {
+      res.result = 42;
+      end();
+    });
+    const provider = providerFromEngine(engine);
+    const promisifiedSendAsync = promisify(provider.sendAsync);
+    const exampleRequest = {
+      id: 1,
+      jsonrpc: '2.0' as const,
+      method: 'test',
+    };
+
+    const response = await promisifiedSendAsync(exampleRequest);
+
+    expect(response.result).toBe(42);
+  });
+
+  it('handle a failed request', async () => {
+    const engine = new JsonRpcEngine();
+    engine.push((_req, _res, _next, _end) => {
+      throw new Error('Test error');
+    });
+    const provider = providerFromEngine(engine);
+    const promisifiedSendAsync = promisify(provider.sendAsync);
+    const exampleRequest = {
+      id: 1,
+      jsonrpc: '2.0' as const,
+      method: 'test',
+    };
+
+    await expect(async () =>
+      promisifiedSendAsync(exampleRequest),
+    ).rejects.toThrow('Test error');
+  });
+});

--- a/src/provider-from-engine.ts
+++ b/src/provider-from-engine.ts
@@ -1,0 +1,15 @@
+import type { JsonRpcEngine } from 'json-rpc-engine';
+
+import { SafeEventEmitterProvider } from './safe-event-emitter-provider';
+
+/**
+ * Construct an Ethereum provider from the given JSON-RPC engine.
+ *
+ * @param engine - The JSON-RPC engine to construct a provider from.
+ * @returns An Ethereum provider.
+ */
+export function providerFromEngine(
+  engine: JsonRpcEngine,
+): SafeEventEmitterProvider {
+  return new SafeEventEmitterProvider({ engine });
+}

--- a/src/provider-from-middleware.ts
+++ b/src/provider-from-middleware.ts
@@ -1,0 +1,20 @@
+import { JsonRpcEngine } from 'json-rpc-engine';
+import type { JsonRpcMiddleware } from 'json-rpc-engine';
+
+import { providerFromEngine } from './provider-from-engine';
+import type { SafeEventEmitterProvider } from './safe-event-emitter-provider';
+
+/**
+ * Construct an Ethereum provider from the given middleware.
+ *
+ * @param middleware - The middleware to construct a provider from.
+ * @returns An Ethereum provider.
+ */
+export function providerFromMiddleware(
+  middleware: JsonRpcMiddleware<unknown, unknown>,
+): SafeEventEmitterProvider {
+  const engine: JsonRpcEngine = new JsonRpcEngine();
+  engine.push(middleware);
+  const provider: SafeEventEmitterProvider = providerFromEngine(engine);
+  return provider;
+}

--- a/src/safe-event-emitter-provider.test.ts
+++ b/src/safe-event-emitter-provider.test.ts
@@ -5,7 +5,7 @@ import { SafeEventEmitterProvider } from './safe-event-emitter-provider';
 
 describe('SafeEventEmitterProvider', () => {
   describe('constructor', () => {
-    it('emit engine notifications from provider', async () => {
+    it('listens for notifications from provider, emitting them as "data"', async () => {
       const engine = new JsonRpcEngine();
       const provider = new SafeEventEmitterProvider({ engine });
       const notificationListener = jest.fn();
@@ -19,7 +19,7 @@ describe('SafeEventEmitterProvider', () => {
       expect(notificationListener).toHaveBeenCalledWith(null, 'test');
     });
 
-    it('do not throw if engine does not support events', () => {
+    it('does not throw if engine does not support events', () => {
       const engine = new JsonRpcEngine() as any;
       delete engine.on;
 
@@ -28,7 +28,7 @@ describe('SafeEventEmitterProvider', () => {
   });
 
   describe('sendAsync', () => {
-    it('handle a successful request', async () => {
+    it('handles a successful request', async () => {
       const engine = new JsonRpcEngine();
       engine.push((_req, res, _next, end) => {
         res.result = 42;
@@ -47,7 +47,7 @@ describe('SafeEventEmitterProvider', () => {
       expect(response.result).toBe(42);
     });
 
-    it('handle a failed request', async () => {
+    it('handles a failed request', async () => {
       const engine = new JsonRpcEngine();
       engine.push((_req, _res, _next, _end) => {
         throw new Error('Test error');
@@ -67,7 +67,7 @@ describe('SafeEventEmitterProvider', () => {
   });
 
   describe('send', () => {
-    it('throw if a callback is not provided', () => {
+    it('throws if a callback is not provided', () => {
       const engine = new JsonRpcEngine();
       const provider = new SafeEventEmitterProvider({ engine });
       const exampleRequest = {
@@ -79,7 +79,7 @@ describe('SafeEventEmitterProvider', () => {
       expect(() => (provider.send as any)(exampleRequest)).toThrow('');
     });
 
-    it('handle a successful request', async () => {
+    it('handles a successful request', async () => {
       const engine = new JsonRpcEngine();
       engine.push((_req, res, _next, end) => {
         res.result = 42;
@@ -98,7 +98,7 @@ describe('SafeEventEmitterProvider', () => {
       expect(response.result).toBe(42);
     });
 
-    it('handle a failed request', async () => {
+    it('handles a failed request', async () => {
       const engine = new JsonRpcEngine();
       engine.push((_req, _res, _next, _end) => {
         throw new Error('Test error');

--- a/src/safe-event-emitter-provider.test.ts
+++ b/src/safe-event-emitter-provider.test.ts
@@ -1,0 +1,119 @@
+import { JsonRpcEngine } from 'json-rpc-engine';
+import { promisify } from 'util';
+
+import { SafeEventEmitterProvider } from './safe-event-emitter-provider';
+
+describe('SafeEventEmitterProvider', () => {
+  describe('constructor', () => {
+    it('emit engine notifications from provider', async () => {
+      const engine = new JsonRpcEngine();
+      const provider = new SafeEventEmitterProvider({ engine });
+      const notificationListener = jest.fn();
+      provider.on('data', notificationListener);
+
+      // `json-rpc-engine` v6 does not support JSON-RPC notifications directly,
+      // so this is the best way to emulate this behavior.
+      // We should replace this with `await engine.handle(notification)` when we update to v7
+      engine.emit('notification', 'test');
+
+      expect(notificationListener).toHaveBeenCalledWith(null, 'test');
+    });
+
+    it('do not throw if engine does not support events', () => {
+      const engine = new JsonRpcEngine() as any;
+      delete engine.on;
+
+      expect(() => new SafeEventEmitterProvider({ engine })).not.toThrow();
+    });
+  });
+
+  describe('sendAsync', () => {
+    it('handle a successful request', async () => {
+      const engine = new JsonRpcEngine();
+      engine.push((_req, res, _next, end) => {
+        res.result = 42;
+        end();
+      });
+      const provider = new SafeEventEmitterProvider({ engine });
+      const promisifiedSendAsync = promisify(provider.sendAsync);
+      const exampleRequest = {
+        id: 1,
+        jsonrpc: '2.0' as const,
+        method: 'test',
+      };
+
+      const response = await promisifiedSendAsync(exampleRequest);
+
+      expect(response.result).toBe(42);
+    });
+
+    it('handle a failed request', async () => {
+      const engine = new JsonRpcEngine();
+      engine.push((_req, _res, _next, _end) => {
+        throw new Error('Test error');
+      });
+      const provider = new SafeEventEmitterProvider({ engine });
+      const promisifiedSendAsync = promisify(provider.sendAsync);
+      const exampleRequest = {
+        id: 1,
+        jsonrpc: '2.0' as const,
+        method: 'test',
+      };
+
+      await expect(async () =>
+        promisifiedSendAsync(exampleRequest),
+      ).rejects.toThrow('Test error');
+    });
+  });
+
+  describe('send', () => {
+    it('throw if a callback is not provided', () => {
+      const engine = new JsonRpcEngine();
+      const provider = new SafeEventEmitterProvider({ engine });
+      const exampleRequest = {
+        id: 1,
+        jsonrpc: '2.0' as const,
+        method: 'test',
+      };
+
+      expect(() => (provider.send as any)(exampleRequest)).toThrow('');
+    });
+
+    it('handle a successful request', async () => {
+      const engine = new JsonRpcEngine();
+      engine.push((_req, res, _next, end) => {
+        res.result = 42;
+        end();
+      });
+      const provider = new SafeEventEmitterProvider({ engine });
+      const promisifiedSend = promisify(provider.send);
+      const exampleRequest = {
+        id: 1,
+        jsonrpc: '2.0' as const,
+        method: 'test',
+      };
+
+      const response = await promisifiedSend(exampleRequest);
+
+      expect(response.result).toBe(42);
+    });
+
+    it('handle a failed request', async () => {
+      const engine = new JsonRpcEngine();
+      engine.push((_req, _res, _next, _end) => {
+        throw new Error('Test error');
+      });
+      const provider = new SafeEventEmitterProvider({ engine });
+      const promisifiedSend = promisify(provider.send);
+      const exampleRequest = {
+        id: 1,
+        jsonrpc: '2.0' as const,
+        method: 'test',
+      };
+
+      await expect(async () => promisifiedSend(exampleRequest)).rejects.toThrow(
+        'Test error',
+      );
+    });
+  });
+});

--- a/src/safe-event-emitter-provider.ts
+++ b/src/safe-event-emitter-provider.ts
@@ -1,0 +1,62 @@
+import SafeEventEmitter from '@metamask/safe-event-emitter';
+import type { JsonRpcEngine, JsonRpcRequest } from 'json-rpc-engine';
+
+/**
+ * An Ethereum provider.
+ *
+ * This provider loosly follows conventions that pre-date EIP-1193. It
+ * is not compliant with any Ethereum provider standard.
+ */
+export class SafeEventEmitterProvider extends SafeEventEmitter {
+  #engine: JsonRpcEngine;
+
+  /**
+   * Construct a SafeEventEmitterProvider from a JSON-RPC engine.
+   *
+   * @param options - Options.
+   * @param options.engine - The JSON-RPC engine used to process requests.
+   */
+  constructor({ engine }: { engine: JsonRpcEngine }) {
+    super();
+    this.#engine = engine;
+
+    if (engine.on) {
+      engine.on('notification', (message: string) => {
+        this.emit('data', null, message);
+      });
+    }
+  }
+
+  /**
+   * Send a provider request asynchronously.
+   *
+   * @param req - The request to send.
+   * @param callback - A function that is called upon the success or failure of the request.
+   */
+  sendAsync = (
+    req: JsonRpcRequest<unknown>,
+    callback: (error: unknown, providerRes?: any) => void,
+  ) => {
+    this.#engine.handle(req, callback);
+  };
+
+  /**
+   * Send a provider request asynchronously.
+   *
+   * This method serves the same purpose as `sendAsync`. It only exists for
+   * legacy reasons.
+   *
+   * @deprecated Use `sendAsync` instead.
+   * @param req - The request to send.
+   * @param callback - A function that is called upon the success or failure of the request.
+   */
+  send = (
+    req: JsonRpcRequest<unknown>,
+    callback: (error: unknown, providerRes?: any) => void,
+  ) => {
+    if (typeof callback !== 'function') {
+      throw new Error('Must provide callback to "send" method.');
+    }
+    this.#engine.handle(req, callback);
+  };
+}

--- a/src/safe-event-emitter-provider.ts
+++ b/src/safe-event-emitter-provider.ts
@@ -4,8 +4,8 @@ import type { JsonRpcEngine, JsonRpcRequest } from 'json-rpc-engine';
 /**
  * An Ethereum provider.
  *
- * This provider loosly follows conventions that pre-date EIP-1193. It
- * is not compliant with any Ethereum provider standard.
+ * This provider loosely follows conventions that pre-date EIP-1193.
+ * It is not compliant with any Ethereum provider standard.
  */
 export class SafeEventEmitterProvider extends SafeEventEmitter {
   #engine: JsonRpcEngine;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,6 +1303,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
+    "@metamask/safe-event-emitter": ^2.0.0
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
     "@typescript-eslint/eslint-plugin": ^5.43.0
@@ -1317,6 +1318,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     jest: ^28.1.3
     jest-it-up: ^2.0.2
+    json-rpc-engine: ^6.1.0
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.3.0
     rimraf: ^3.0.2
@@ -1326,6 +1328,13 @@ __metadata:
     typescript: ~4.8.4
   languageName: unknown
   linkType: soft
+
+"@metamask/safe-event-emitter@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/safe-event-emitter@npm:2.0.0"
+  checksum: 8b717ac5d53df0027c05509f03d0534700b5898dd1c3a53fb2dc4c0499ca5971b14aae67f522d09eb9f509e77f50afa95fdb3eda1afbff8b071c18a3d2905e93
+  languageName: node
+  linkType: hard
 
 "@nodelib/fs.scandir@npm:2.1.4":
   version: 2.1.4
@@ -3451,6 +3460,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eth-rpc-errors@npm:^4.0.2":
+  version: 4.0.3
+  resolution: "eth-rpc-errors@npm:4.0.3"
+  dependencies:
+    fast-safe-stringify: ^2.0.6
+  checksum: 5fa31d1a10fdb340733b9a55e38e7687222c501052ca20743cef4d0c911a9bbcc0cad54aa6bf3e4b428604c071ff519803060e1cbc79ddb7c9257c11d407d32a
+  languageName: node
+  linkType: hard
+
 "execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -3560,6 +3578,13 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 92cfec0a8dfafd9c7a15fba8f2cc29cd0b62b85f056d99ce448bbcd9f708e18ab2764bda4dd5158364f4145a7c72788538994f0d1787b956ef0d1062b0f7c24c
+  languageName: node
+  linkType: hard
+
+"fast-safe-stringify@npm:^2.0.6":
+  version: 2.1.1
+  resolution: "fast-safe-stringify@npm:2.1.1"
+  checksum: a851cbddc451745662f8f00ddb622d6766f9bd97642dabfd9a405fb0d646d69fc0b9a1243cbf67f5f18a39f40f6fa821737651ff1bceeba06c9992ca2dc5bd3d
   languageName: node
   linkType: hard
 
@@ -5059,6 +5084,16 @@ __metadata:
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
+  languageName: node
+  linkType: hard
+
+"json-rpc-engine@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "json-rpc-engine@npm:6.1.0"
+  dependencies:
+    "@metamask/safe-event-emitter": ^2.0.0
+    eth-rpc-errors: ^4.0.2
+  checksum: 33b6c9bbd81abf8e323a0281ee05871713203c40d34a4d0bda27706cd0a0935c7b51845238ba89b73027e44ebc8034bbd82db9f962e6c578eb922d9b95acc8bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The functions `providerFromEngine` and `providerFromMiddleware` have been migrated from `@metamask/eth-json-rpc-middleware`.

The `SafeEventEmitterProvider` is now a class with its own separate module, rather than a type. Hopefully this will help prevent future type errors. The error in the `SafeEventEmitterProvider` type in `@metamask/eth-json-rpc-middleware` has been corrected; the response in in the callback is now optional.

Everything should be fully documented and tested.