### PR TITLE
Decrement version ahead of v1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-json-rpc-provider",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Create an Ethereum provider using a JSON-RPC engine or middleware",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The version has been changed to v0.0.1 so that the first release can be v1. I set this to v1 forgetting that our release automation would also attempt to set this.