### PR TITLE
Introduce SafeEventEmitterProvider interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export * from './provider-from-engine';
 export * from './provider-from-middleware';
-export type { SafeEventEmitterProvider } from './safe-event-emitter-provider';
+export type {
+  ISafeEventEmitterProvider,
+  SafeEventEmitterProvider,
+} from './safe-event-emitter-provider';

--- a/src/safe-event-emitter-provider.ts
+++ b/src/safe-event-emitter-provider.ts
@@ -2,12 +2,49 @@ import SafeEventEmitter from '@metamask/safe-event-emitter';
 import type { JsonRpcEngine, JsonRpcRequest } from 'json-rpc-engine';
 
 /**
+ * The interface for an Ethereum provider.
+ *
+ * This provider loosely follows conventions that pre-date EIP-1193.
+ * It is not compliant with any Ethereum provider standard.
+ */
+export type ISafeEventEmitterProvider = {
+  /**
+   * Send a provider request asynchronously.
+   *
+   * @param req - The request to send.
+   * @param callback - A function that is called upon the success or failure of the request.
+   */
+  sendAsync(
+    req: JsonRpcRequest<unknown>,
+    callback: (error: unknown, providerRes?: any) => void,
+  ): void;
+
+  /**
+   * Send a provider request asynchronously.
+   *
+   * This method serves the same purpose as `sendAsync`. It only exists for
+   * legacy reasons.
+   *
+   * @deprecated Use `sendAsync` instead.
+   * @param req - The request to send.
+   * @param callback - A function that is called upon the success or failure of the request.
+   */
+  send(
+    req: JsonRpcRequest<unknown>,
+    callback: (error: unknown, providerRes?: any) => void,
+  ): void;
+};
+
+/**
  * An Ethereum provider.
  *
  * This provider loosely follows conventions that pre-date EIP-1193.
  * It is not compliant with any Ethereum provider standard.
  */
-export class SafeEventEmitterProvider extends SafeEventEmitter {
+export class SafeEventEmitterProvider
+  extends SafeEventEmitter
+  implements ISafeEventEmitterProvider
+{
   #engine: JsonRpcEngine;
 
   /**


### PR DESCRIPTION
In some controller tests it's useful to create a fake provider that conforms to the same interface as a "real" provider but doesn't actually hit the network. To make such a fake provider, however, we must create a class that extends SafeEventEmitterProvider. This is unfortunate as it introduces the possibility that the network could be hit accidentally if not all of the methods in the interface are appropriately overridden.

This commit introduces an interface that allows us to _implement_ the same interface without having to extend it.

---

An alternative solution to #12.