### PR TITLE
Retract v1.0.1 (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1]
+## [1.0.1] [RETRACTED]
 ### Changed
 - Updated dependencies: ([#16](https://github.com/MetaMask/eth-json-rpc-provider/pull/16))
   - Switched json-rpc-engine@^6.1.0 -> @metamask/json-rpc-engine@^7.0.0


### PR DESCRIPTION
v1.0.1 contains two changes that should have been considered semver-major:

- Type-interface -incompatability with previous version (https://github.com/MetaMask/json-rpc-engine/pull/139)
- Introduced dependency `@metamask/json-rpc-engine` indicates a minimum supported Node.js version of 16. This prevents the module from installing on some package manager configurations, like default yarn classic.

This will be re-released as v2.0.0.
